### PR TITLE
pdfarranger: Initial commit

### DIFF
--- a/src/pdfarranger/package.yml
+++ b/src/pdfarranger/package.yml
@@ -1,0 +1,22 @@
+name       : pdfarranger
+version    : 1.4.2
+release    : 1
+source     :
+    - https://github.com/jeromerobert/pdfarranger/archive/1.4.2.tar.gz : 7fcf7bb3cc4a093a17013bac3c3857e9dcfd46aa3814d17287b58bac9ae90772
+homepage   : https://github.com/jeromerobert/pdfarranger
+license    : GPL-3.0-or-later
+component  : office
+summary    : Small application to merge or split pdf documents and rotate, crop and rearrange their pages using an interactive and intuitive graphical interface
+description: |
+    pdfarranger is a small python-gtk application, which helps the user to merge or split pdf documents and rotate, crop and rearrange their pages using an interactive and intuitive graphical interface. It is a frontend for python-pyPdf
+builddeps  :
+    - python-distutils-extra
+rundeps    :
+    - poppler
+    - python-pikepdf
+    - python3-cairo
+    - python3-gobject
+build      : |
+    %python3_setup
+install    : |
+    %python3_install

--- a/src/python-pikepdf/package.yml
+++ b/src/python-pikepdf/package.yml
@@ -1,0 +1,22 @@
+name       : python-pikepdf
+version    : 1.11.0
+release    : 1
+source     :
+    - https://github.com/pikepdf/pikepdf/archive/v1.11.0.tar.gz : 680bcf19a722039a3931a54b783cb05d2fab84c3e34ad26bdf774fad91cf886a
+homepage   : https://pikepdf.readthedocs.io/
+license    : MPL-2.0
+component  : programming.python
+summary    : A Python library for reading and writing PDF, powered by qpdf
+description: |
+    Pikepdf is a Python library for reading and writing PDF files.
+builddeps  :
+    - pkgconfig(libqpdf)
+    - pkgconfig(python3)
+    - pybind11
+    - python-setuptools-scm-git-archive
+rundeps    :
+    - python-lxml
+build      : |
+    %python3_setup
+install    : |
+    %python3_install

--- a/src/python-setuptools-scm-git-archive/package.yml
+++ b/src/python-setuptools-scm-git-archive/package.yml
@@ -1,0 +1,22 @@
+name       : python-setuptools-scm-git-archive
+version    : 1.1
+release    : 1
+source     :
+    - https://files.pythonhosted.org/packages/source/s/setuptools_scm_git_archive/setuptools_scm_git_archive-1.1.tar.gz : 6026f61089b73fa1b5ee737e95314f41cb512609b393530385ed281d0b46c062
+homepage   : https://github.com/pypa/setuptools_scm/
+license    : MIT
+component  : programming.python
+summary    : setuptools_scm plugin for git archives
+description: |
+    This is a setuptools_scm plugin that adds support for git archives (for example the ones GitHub automatically generates).
+builddeps  :
+    - python-pytest
+    - python-setuptools-scm
+rundeps    :
+    - python-setuptools-scm
+build      : |
+    %python3_setup
+install    : |
+    %python3_install
+check      : |
+    %python3_test

--- a/src/series
+++ b/src/series
@@ -60,6 +60,7 @@
   - pantheon-wallpapers
   - paperboy
   - python-pam
+  - python-setuptools-scm-git-archive
   - python-tinycss
   - qview
   - sideload
@@ -93,6 +94,7 @@
   - muffin
   - nemo
   - pantheon-tweaks
+  - python-pikepdf
   - qtermwidget
   - xfconf
 - group-3:
@@ -102,6 +104,7 @@
   - liblxqt
   - libxfce4ui
   - lxqt-qtplugin
+  - pdfarranger
   - qterminal
   - switchboard-plug-a11y
   - switchboard-plug-about


### PR DESCRIPTION
Let this package stay here until core team decide to include it in main repository.
I am looking forward to be the maintainer if this package.
[Reference](https://dev.getsol.us/T7307)

Build order should be:
1. python-setuptools-scm-git-archive
2. python-pikepdf
3. pdfarranger