### PR TITLE
pocillo-gtk-theme: Initial commit

### DIFF
--- a/src/pocillo-gtk-theme/package.yml
+++ b/src/pocillo-gtk-theme/package.yml
@@ -1,0 +1,30 @@
+name       : pocillo-gtk-theme
+version    : 0.6
+release    : 1
+source     :
+    - https://github.com/UbuntuBudgie/pocillo-gtk-theme/archive/v0.6.tar.gz : eb91742cd4240e2e2ba48abfdb8022bc3886c2f72b480a6111487cee771f0da9
+homepage   : https://github.com/UbuntuBudgie/pocillo-gtk-theme
+license    :
+    - CC-BY-SA-4.0
+    - GPL-2.0-or-later
+component  : desktop.theme
+summary    : Material Design GTK Theme
+description: |
+    GTK based theme for the Budgie Desktop that has Material Design elements and styled using the Arc colour palette 
+builddeps  :
+    - inkscape
+    - optipng
+    - sassc
+rundeps    : 
+    - gtk-engines
+    - gtk2-engine-murrine
+build      : |
+    %make
+install    : |
+    %make_install
+
+    #Fix broken symbolic links for gkt-3.0
+    for themes in Pocillo Pocillo-dark Pocillo-dark-slim Pocillo-light Pocillo-light-slim Pocillo-slim ; do
+        rm $installdir/usr/share/themes/${themes}/gtk-3.0
+        ln -sv /usr/share/themes/${themes}/gtk-3.22 $installdir/usr/share/themes/${themes}/gtk-3.0
+    done

--- a/src/series
+++ b/src/series
@@ -57,6 +57,7 @@
 - pantheon-videos
 - pantheon-wallpapers
 - paperboy
+- pocillo-gtk-theme
 - python-pam
 - python-setuptools-scm-git-archive
 - python-tinycss


### PR DESCRIPTION
This theme is developed by Ubuntu Budgie team and it works fine in Budgie Desktop.
I have been using this as main theme for over a month. At the moment this package wasn't accepted for inclusion in [Solus Repo.](https://dev.getsol.us/T8944)