### PR TITLE
vscodium: Update to 1.45.0

### DIFF
--- a/src/vscodium/package.yml
+++ b/src/vscodium/package.yml
@@ -1,8 +1,8 @@
 name       : vscodium
-version    : 1.44.2
-release    : 17
+version    : 1.45.0
+release    : 18
 source     :
-    - https://github.com/VSCodium/vscodium/releases/download/1.44.2/codium_1.44.2-1587206561_amd64.deb : a42a78600716213b20c1d4f8753b225e9e6069de27393021375f2401d383171d
+    - https://github.com/VSCodium/vscodium/releases/download/1.45.0/codium_1.45.0-1588934730_amd64.deb : c735a68bcbd6b58f4691edfadc4303b5a91e11953e5d13e0a92e56831bcc2486
 license    : MIT
 component  : programming.ide
 summary    : Visual Studio Code without MS branding, telemetry and licensing
@@ -12,8 +12,12 @@ description: |
     These binaries are licensed under the MIT license.
     Telemetry is disabled.
 builddeps  :
-    - tar
-    - binutils
+    - pkgconfig(alsa)
+    - pkgconfig(gtk+-3.0)
+    - pkgconfig(libsecret-1)
+    - pkgconfig(xext)
+    - pkgconfig(xkbfile)
+    - pkgconfig(xscrnsaver)
 setup      : |
     mkdir -p $installdir
 install    : |


### PR DESCRIPTION
`tar` and `binutils` no need to be added as builddeps.