### PR TITLE
conky-manager2: Initial commit

### DIFF
--- a/src/conky-manager2/files/makefile-roundup.patch
+++ b/src/conky-manager2/files/makefile-roundup.patch
@@ -1,0 +1,45 @@
+--- src/makefile	2015-10-22 22:12:09.111700293 +0200
++++ src/makefile	2015-10-22 22:12:29.688347815 +0200
+@@ -11,7 +11,7 @@
+ 
+ all:
+ 	#build binaries
+-	valac -X -D'GETTEXT_PACKAGE="${app_name}"' --Xcc="-lm" -X -Wl,-rpath,/usr/share/${app_name}/libs "Main.vala" "MainWindow.vala" "EditWidgetWindow.vala" "EditThemeWindow.vala" "SettingsWindow.vala" "DonationWindow.vala" "GeneratePreviewWindow.vala" "AboutWindow.vala" "Utility.vala" -o ${app_name} --pkg glib-2.0 --pkg gio-unix-2.0 --pkg posix --pkg gtk+-3.0 --pkg gee-0.8 --pkg json-glib-1.0 
++	valac -X -D'GETTEXT_PACKAGE="${app_name}"' --Xcc="-lm"  "Main.vala" "MainWindow.vala" "EditWidgetWindow.vala" "EditThemeWindow.vala" "SettingsWindow.vala" "DonationWindow.vala" "GeneratePreviewWindow.vala" "AboutWindow.vala" "Utility.vala" -o ${app_name} --pkg glib-2.0 --pkg gio-unix-2.0 --pkg posix --pkg gtk+-3.0 --pkg gee-0.8 --pkg json-glib-1.0 
+ 	
+ 	#update translation template
+ 	xgettext --language=C --keyword=_ --copyright-holder='Tony George (teejee2008@gmail.com)' --package-name='${app_name}' --package-version='2.0' --msgid-bugs-address='teejee2008@gmail.com' --escape --sort-output -o ../${app_name}.pot *.vala
+@@ -29,20 +29,20 @@
+ 	
+ 	#binary
+ 	install -m 0755 ${app_name} "$(DESTDIR)$(bindir)"
+-	install -m 0755 ${app_name}-uninstall "$(DESTDIR)$(bindir)"
+ 	
+ 	#launcher
+-	install -m 0755 ${app_name}.desktop "$(DESTDIR)$(launcherdir)"
++	install -m 644 ${app_name}.desktop "$(DESTDIR)$(launcherdir)"
+ 	
+ 	#app icon
+-	install -m 0755 share/pixmaps/${app_name}.png "$(DESTDIR)$(sharedir)/pixmaps"
++	install -m 644 share/pixmaps/${app_name}.png "$(DESTDIR)$(sharedir)/pixmaps"
+ 	
+ 	#appdata.xml
+-	install -m 0755 ${app_name}.appdata.xml "$(DESTDIR)$(sharedir)/appdata"
++	install -m 644 ${app_name}.appdata.xml "$(DESTDIR)$(sharedir)/appdata"
+ 	
+ 	#shared files
+ 	cp -dpr --no-preserve=ownership -t "$(DESTDIR)$(sharedir)/${app_name}" ./share/${app_name}/*
+-	chmod --recursive 0755 $(DESTDIR)$(sharedir)/${app_name}/*
++	chmod --recursive 644 $(DESTDIR)$(sharedir)/${app_name}/*
++	find $(DESTDIR)$(sharedir)/${app_name} -type d -exec chmod +x '{}' +
+ 	
+ 	#translations
+ 	mkdir -p "$(DESTDIR)$(localedir)/cs_CZ/LC_MESSAGES"
+@@ -54,7 +54,6 @@
+ uninstall:
+ 	#binary
+ 	rm -f "$(DESTDIR)$(bindir)/${app_name}"
+-	rm -f "$(DESTDIR)$(bindir)/${app_name}-uninstall"
+ 	
+ 	#launcher
+ 	rm -f "$(DESTDIR)$(launcherdir)/${app_name}.desktop"

--- a/src/conky-manager2/package.yml
+++ b/src/conky-manager2/package.yml
@@ -1,0 +1,29 @@
+maintainer : algent-al
+name       : conky-manager2
+version    : 2.7
+release    : 1
+source     :
+    - git|https://github.com/zcot/conky-manager2 : d0d6cb279746049df30de3af4d61e571086a885e
+license    : GPL-3.0-or-later
+component  : system.utils
+summary    : Conky Manager 2 - a newer conky config manager
+description: |
+    This is a fork of the old original Conky Manager by teejee2008(Tony George). This is a graphical front-end for managing Conky config files. It provides options to start/stop, browse and edit Conky themes installed on the system. It also provides support for the newer lua-based conky and configuration files(v1.10)
+builddeps  :
+    - pkgconfig(cairo)
+    - pkgconfig(gee-0.8)
+    - pkgconfig(gtk+-3.0)
+    - pkgconfig(ImageMagick)
+    - pkgconfig(json-glib-1.0)
+    - pkgconfig(libsoup-2.4)
+    - vala
+rundeps    :
+    - conky
+    - imagemagick
+    - p7zip
+    - rsync
+build      : |
+    %patch -Np0 < $pkgfiles/makefile-roundup.patch
+    %make
+install    : |
+    %make_install

--- a/src/series
+++ b/src/series
@@ -7,6 +7,7 @@
 - cinnamon-desktop
 - cinnamon-menus
 - cinnamon-translations
+- conky-manager2
 - contractor
 - crond
 - dwm

--- a/src/series
+++ b/src/series
@@ -241,3 +241,4 @@
 - deepin-terminal
 - deepin-wallpapers
 - startdde
+- kwin


### PR DESCRIPTION
Main reason for including this is that it provides support for the newer lua-based conky and configuration files (v1.10). Probably in the future this will replace current `conky-manager` that is in the main repo which was abandoned by its developer.