### PR TITLE
ubuntu-budgie-extras: Initial inclusion

### DIFF
--- a/src/pytest-isort/package.yml
+++ b/src/pytest-isort/package.yml
@@ -1,0 +1,18 @@
+maintainer : algent-al
+name       : pytest-isort
+version    : 1.0.0
+release    : 1
+source     :
+    - https://github.com/moccu/pytest-isort/archive/1.0.0.tar.gz : 34f851b097c0f1cade63faa948f468de49ebaca9e034d23ca91b33c02571ad3c
+homepage   : https://github.com/moccu/pytest-isort
+license    : BSD-3-Clause
+component  : programming.python
+summary    : py.test plugin to check import ordering using isort
+description: |
+    py.test plugin to check import ordering using isort
+rundeps    :
+    - python-isort
+build      : |
+    %python3_setup
+install    : |
+    %python3_install

--- a/src/python-cairocffi/package.yml
+++ b/src/python-cairocffi/package.yml
@@ -1,0 +1,30 @@
+maintainer : algent-al
+name       : python-cairocffi
+version    : 1.1.0
+release    : 1
+source     :
+    - https://github.com/Kozea/cairocffi/archive/v1.1.0.tar.gz : 52b6c6d61c14c7cc97cc6309e54f8435fc61dff4c258f89ad08ecb48bce15af7
+homepage   : https://cairocffi.readthedocs.io/en/stable/
+license    : BSD-3-Clause
+component  : programming.python
+summary    : CFFI-based cairo bindings for Python
+description: |
+    cairocffi is a CFFI-based drop-in replacement for Pycairo, a set of Python bindings and object-oriented API for cairo. Cairo is a 2D vector graphics library with support for multiple backends including image buffers, PNG, PostScript, PDF, and SVG file output.
+builddeps  :
+    - gdk-pixbuf
+    - libcairo
+    - pytest-isort
+    - pytest-runner
+    - python-cffi
+    - python-pytest-cov
+    - python-pytest-flake8
+rundeps    :
+    - gdk-pixbuf
+    - libcairo
+    - python-cffi
+build      : |
+    %python3_setup
+install    : |
+    %python3_install
+check      : |
+    %python3_test

--- a/src/python-cairosvg/package.yml
+++ b/src/python-cairosvg/package.yml
@@ -1,0 +1,34 @@
+maintainer : algent-al
+name       : python-cairosvg
+version    : 2.4.2
+release    : 1
+source     :
+    - https://github.com/Kozea/CairoSVG/archive/2.4.2.tar.gz : ae988993f8e3e79f8da1cc6fe4f16f9b3f4b7e174c19f5ab61444564bf003086
+homepage   : https://cairosvg.org/
+license    : LGPL-3.0-or-later
+component  : programming.python
+summary    : CairoSVG is a SVG converter based on Cairo
+description: |
+    CairoSVG is a SVG converter based on Cairo. It can export SVG files to PDF, PostScript and PNG files.
+builddeps  :
+    - pytest-runner
+    - pytest-isort
+    - python-cairocffi
+    - python-cssselect2
+    - python-defusedxml
+    - python-pillow
+    - python-pytest-cov
+    - python-pytest-flake8
+rundeps    :
+    - python-cairocffi
+    - python-cssselect2
+    - python-defusedxml
+    - python-pillow
+setup      : |
+    cp -r cairosvg test_non_regression/cairosvg_reference/
+build      : |
+    %python3_setup
+install    : |
+    %python3_install
+check      : |
+    %python3_test

--- a/src/python-cssselect2/package.yml
+++ b/src/python-cssselect2/package.yml
@@ -1,0 +1,26 @@
+maintainer : algent-al
+name       : python-cssselect2
+version    : 0.3.0
+release    : 1
+source     :
+    - https://files.pythonhosted.org/packages/03/37/0e28364d4c2bce998171199ab59650b3174c077ef2c8b6d4ff57aa47676a/cssselect2-0.3.0.tar.gz : 5c2716f06b5de93f701d5755a9666f2ee22cbcd8b4da8adddfc30095ffea3abc
+homepage   : https://pypi.org/project/cssselect2/
+license    : BSD-3-Clause
+component  : programming.python
+summary    : CSS selectors for Python ElementTree
+description: |
+    cssselect2 is a straightforward implementation of CSS3 Selectors for markup documents (HTML, XML, etc.) that can be read by ElementTree-like parsers (including cElementTree, lxml, html5lib, etc.)
+builddeps  :
+    - pytest-isort
+    - pytest-runner
+    - python-pytest-cov
+    - python-pytest-flake8
+    - python-tinycss2
+rundeps    :
+    - python-tinycss2
+build      : |
+    %python3_setup
+install    : |
+    %python3_install
+check      : |
+    %python3_test

--- a/src/python-svgwrite/package.yml
+++ b/src/python-svgwrite/package.yml
@@ -1,0 +1,16 @@
+maintainer : algent-al
+name       : python-svgwrite
+version    : 1.4
+release    : 1
+source     :
+    - https://github.com/mozman/svgwrite/archive/v1.4.tar.gz : fd0f9659351ad93b524420bdf0449670b9f4e97c3763bdc98706c77fb654197d
+homepage   : https://github.com/mozman/svgwrite
+license    : MIT
+component  : programming.python
+summary    : Python Package to write SVG files
+description: |
+    As the name svgwrite implies, svgwrite creates new SVG drawings, it does not read existing drawings and also does not import existing drawings, but you can always include other SVG drawings by the <image> entity.
+build      : |
+    %python3_setup
+install    : |
+    %python3_install

--- a/src/python-tinyccs2/package.yml
+++ b/src/python-tinyccs2/package.yml
@@ -1,0 +1,26 @@
+maintainer : algent-al
+name       : python-tinycss2
+version    : 1.0.2
+release    : 1
+source     :
+    - https://github.com/Kozea/tinycss2/archive/v1.0.2.tar.gz : 21b9c016d73168c63e5ce20a9fa8e4695c6989c78e89c368c083967c45995def
+homepage   : https://tinycss2.readthedocs.io/
+license    : BSD-3-Clause
+component  : programming.python
+summary    : Low-level CSS parser for Python
+description: |
+    tinycss2 is a low-level CSS parser and generator: it can parse strings, return Python objects representing tokens and blocks, and generate CSS strings corresponding to these objects.
+builddeps  :
+    - pytest-runner
+    - pytest-isort
+    - python-pytest-cov
+    - python-pytest-flake8
+    - python-webencodings
+rundeps    :
+    - python-webencodings
+build      : |
+    %python3_setup
+install    : |
+    %python3_install
+check      : |
+    %python3_test

--- a/src/series
+++ b/src/series
@@ -60,8 +60,10 @@
 - pantheon-wallpapers
 - paperboy
 - pocillo-gtk-theme
+- pytest-isort
 - python-pam
 - python-setuptools-scm-git-archive
+- python-svgwrite
 - python-tinycss
 - qview
 - sideload
@@ -76,6 +78,7 @@
 - variety-slideshow
 - vscodium
 - webpin
+- wmctrl
 - xapps
 - xfce4-dev-tools
 - youtube-dlg
@@ -97,7 +100,9 @@
 - muffin
 - nemo
 - pantheon-tweaks
+- python-cairocffi
 - python-pikepdf
+- python-tinycss2
 - qtermwidget
 - xfconf
 # group separator
@@ -131,6 +136,7 @@
 - pdfarranger
 - perl-config-tiny
 - proxychains-ng
+- python-cssselect2
 - qt5-xcb-private-headers
 - qterminal
 - switchboard-plug-a11y
@@ -153,6 +159,7 @@
 - switchboard-plug-sharing
 - switchboard-plug-sound
 - switchboard-plug-useraccounts
+- ubuntu-budgie-extras
 - udisks2-qt5
 - wingpanel
 - xcur2png
@@ -178,6 +185,7 @@
 - pantheon-applications-menu
 - pantheon-greeter
 - pcmanfm-qt
+- python-cairosvg
 - thunar
 - treefrog-framework
 - wingpanel-indicator-a11y

--- a/src/ubuntu-budgie-extras/files/0001-budgie-dropby-dir-path-fix.patch
+++ b/src/ubuntu-budgie-extras/files/0001-budgie-dropby-dir-path-fix.patch
@@ -1,0 +1,38 @@
+diff --git a/budgie-dropby/budgie_dropby.py b/budgie-dropby/budgie_dropby.py
+index d77bb0d..042e389 100644
+--- a/budgie-dropby/budgie_dropby.py
++++ b/budgie-dropby/budgie_dropby.py
+@@ -95,7 +95,7 @@ class BudgieDropByApplet(Budgie.Applet):
+     def start_dropover(self):
+         try:
+             pid = subprocess.check_output(
+-                ["/usr/bin/pgrep", "-f", self.winpath]
++                ["/bin/pgrep", "-f", self.winpath]
+             )
+         except subprocess.CalledProcessError:
+             subprocess.Popen(self.winpath)
+diff --git a/budgie-dropby/dropover b/budgie-dropby/dropover
+index 5fa550c..1685051 100755
+--- a/budgie-dropby/dropover
++++ b/budgie-dropby/dropover
+@@ -58,7 +58,7 @@ class WatchVolumes:
+     def process_check(self, process):
+         try:
+             pid = subprocess.check_output([
+-                "/usr/bin/pgrep", "-f", process
++                "/bin/pgrep", "-f", process
+             ]).decode("utf-8")
+             return True
+         except subprocess.CalledProcessError:
+@@ -66,7 +66,7 @@ class WatchVolumes:
+ 
+     def process_kill(self, procname):
+         try:
+-            subprocess.call(["/usr/bin/pkill", "-f", procname])
++            subprocess.call(["/bin/pkill", "-f", procname])
+         except subprocess.CalledProcessError:
+             pass
+ 
+-- 
+2.26.0
+

--- a/src/ubuntu-budgie-extras/files/0001-budgie-hotcorners-dir-path-fix.patch
+++ b/src/ubuntu-budgie-extras/files/0001-budgie-hotcorners-dir-path-fix.patch
@@ -1,0 +1,25 @@
+diff --git a/budgie-hotcorners/src/HotCornersApplet.vala b/budgie-hotcorners/src/HotCornersApplet.vala
+index 7d39160..4f07de5 100644
+--- a/budgie-hotcorners/src/HotCornersApplet.vala
++++ b/budgie-hotcorners/src/HotCornersApplet.vala
+@@ -28,7 +28,7 @@ namespace HCSupport {
+ 
+ 
+     private bool locked () {
+-        string cmd = "/usr/bin/pgrep -f gnome-screensaver-dialog";
++        string cmd = "/bin/pgrep -f gnome-screensaver-dialog";
+         string output;
+         try {
+             GLib.Process.spawn_command_line_sync(cmd, out output);
+@@ -351,7 +351,7 @@ namespace HotCornersApplet {
+         }
+ 
+         private bool procruns (string processname) {
+-            string cmd = @"/usr/bin/pgrep -f $processname";
++            string cmd = @"/bin/pgrep -f $processname";
+             string output;
+             try {
+                 GLib.Process.spawn_command_line_sync(cmd, out output);
+-- 
+2.26.0
+

--- a/src/ubuntu-budgie-extras/files/0001-budgie-previews-dir-path-fix.patch
+++ b/src/ubuntu-budgie-extras/files/0001-budgie-previews-dir-path-fix.patch
@@ -1,0 +1,23 @@
+diff --git a/budgie-wpreviews/src/previews_controls.vala b/budgie-wpreviews/src/previews_controls.vala
+index 9f8daf5..e8a15a0 100644
+--- a/budgie-wpreviews/src/previews_controls.vala
++++ b/budgie-wpreviews/src/previews_controls.vala
+@@ -120,7 +120,7 @@ namespace PreviewsControls {
+         }
+ 
+         private bool procruns (string processname) {
+-            string cmd = @"/usr/bin/pgrep -f $processname";
++            string cmd = @"/bin/pgrep -f $processname";
+             string output;
+             try {
+                 GLib.Process.spawn_command_line_sync(cmd, out output);
+@@ -168,4 +168,4 @@ namespace PreviewsControls {
+         controls.show_all();
+         Gtk.main();
+     }
+-}
+\ No newline at end of file
++}
+-- 
+2.26.0
+

--- a/src/ubuntu-budgie-extras/files/0001-budgie-wallstreet-fix-dir-path.patch
+++ b/src/ubuntu-budgie-extras/files/0001-budgie-wallstreet-fix-dir-path.patch
@@ -1,0 +1,43 @@
+diff --git a/budgie-wallstreet/src/wallstreet_control/wallstreet_control.vala b/budgie-wallstreet/src/wallstreet_control/wallstreet_control.vala
+index a1a4a91..ae99398 100644
+--- a/budgie-wallstreet/src/wallstreet_control/wallstreet_control.vala
++++ b/budgie-wallstreet/src/wallstreet_control/wallstreet_control.vala
+@@ -206,7 +206,7 @@ namespace WallStreetControls {
+         }
+ 
+         private bool processruns (string application) {
+-            string cmd = "/usr/bin/pgrep -f " + application;
++            string cmd = "/bin/pgrep -f " + application;
+             string output;
+             try {
+                 GLib.Process.spawn_command_line_sync(cmd, out output);
+@@ -316,4 +316,4 @@ namespace WallStreetControls {
+         Gtk.main();
+         return 0;
+     }
+-}
+\ No newline at end of file
++}
+diff --git a/budgie-wallstreet/schema/org.ubuntubudgie.budgie-wallstreet.gschema.xml b/budgie-wallstreet/schema/org.ubuntubudgie.budgie-wallstreet.gschema.xml
+index ec0617a..7fb941e 100644
+--- a/budgie-wallstreet/schema/org.ubuntubudgie.budgie-wallstreet.gschema.xml
++++ b/budgie-wallstreet/schema/org.ubuntubudgie.budgie-wallstreet.gschema.xml
+@@ -25,13 +25,13 @@
+         <key type="s" name="wallpaperfolder">
+             <summary>Folder with wallpapers</summary>
+             <description>The default folder that WallStreet should use to find the wallpapers</description>
+-            <default>"/usr/share/backgrounds/budgie"</default>
++            <default>"/usr/share/backgrounds/solus"</default>
+         </key>
+ 
+         <key type="s" name="fallbackwallpaper">
+             <summary>The backround to set in case of an errors</summary>
+             <description>In case there are no files in the used folder, a fallback image will be used</description>
+-            <default>"/usr/share/backgrounds/budgie/ubuntu_budgie_wallpaper1.jpg"</default>
++            <default>"/usr/share/backgrounds/solus/Pines.jng"</default>
+         </key>
+ 
+     </schema>
+-- 
+2.26.1
+

--- a/src/ubuntu-budgie-extras/files/0001-budgie-window-mover-dir-path-fix.patch
+++ b/src/ubuntu-budgie-extras/files/0001-budgie-window-mover-dir-path-fix.patch
@@ -1,0 +1,29 @@
+diff --git a/budgie-wmover/budgie-wmover.py b/budgie-wmover/budgie-wmover.py
+index b994b99..f2e49ac 100644
+--- a/budgie-wmover/budgie-wmover.py
++++ b/budgie-wmover/budgie-wmover.py
+@@ -36,7 +36,7 @@ def check_runs(pname):
+     # get the pid of a proc
+     try:
+         pid = subprocess.check_output([
+-            "/usr/bin/pgrep", "-f", "-u", user, pname,
++            "/bin/pgrep", "-f", "-u", user, pname,
+         ]).decode("utf-8")
+     except subprocess.CalledProcessError:
+         return None
+diff --git a/budgie-wmover/wmover_panelrunner b/budgie-wmover/wmover_panelrunner
+index 7a1a772..a8c2d3b 100755
+--- a/budgie-wmover/wmover_panelrunner
++++ b/budgie-wmover/wmover_panelrunner
+@@ -34,7 +34,7 @@ def get_pid():
+     app = os.path.join(appletpath, "wmover_run")
+     try:
+         return int(subprocess.check_output([
+-            "/usr/bin/pgrep", "-f", "-u", user, app,
++            "/bin/pgrep", "-f", "-u", user, app,
+         ]).decode("utf-8").strip())
+     except subprocess.CalledProcessError:
+         return subprocess.Popen(app).pid
+-- 
+2.26.0
+

--- a/src/ubuntu-budgie-extras/files/0001-budgie-window-shuffler-dir-path-fix.patch
+++ b/src/ubuntu-budgie-extras/files/0001-budgie-window-shuffler-dir-path-fix.patch
@@ -1,0 +1,36 @@
+diff --git a/budgie-window-shuffler/src/jump.vala b/budgie-window-shuffler/src/jump.vala
+index b761c6a..9d4117c 100644
+--- a/budgie-window-shuffler/src/jump.vala
++++ b/budgie-window-shuffler/src/jump.vala
+@@ -47,7 +47,7 @@ namespace JumpActive {
+     }
+ 
+     private bool procruns (string processname) {
+-        string cmd = @"/usr/bin/pgrep -f $processname";
++        string cmd = @"/bin/pgrep -f $processname";
+         string output;
+         try {
+             GLib.Process.spawn_command_line_sync(cmd, out output);
+@@ -233,4 +233,4 @@ namespace JumpActive {
+             stderr.printf ("%s\n", e.message);
+         }
+     }
+-}
+\ No newline at end of file
++}
+diff --git a/budgie-window-shuffler/src/shuffler_control.vala b/budgie-window-shuffler/src/shuffler_control.vala
+index 66dcfc2..9235784 100644
+--- a/budgie-window-shuffler/src/shuffler_control.vala
++++ b/budgie-window-shuffler/src/shuffler_control.vala
+@@ -591,7 +591,7 @@ namespace ShufflerControls {
+         }
+ 
+         private bool procruns (string processname) {
+-            string cmd = @"/usr/bin/pgrep -f $processname";
++            string cmd = @"/bin/pgrep -f $processname";
+             string output;
+             try {
+                 GLib.Process.spawn_command_line_sync(cmd, out output);
+-- 
+2.26.0
+

--- a/src/ubuntu-budgie-extras/files/series
+++ b/src/ubuntu-budgie-extras/files/series
@@ -1,0 +1,6 @@
+0001-budgie-dropby-dir-path-fix.patch
+0001-budgie-hotcorners-dir-path-fix.patch
+0001-budgie-previews-dir-path-fix.patch
+0001-budgie-wallstreet-fix-dir-path.patch
+0001-budgie-window-mover-dir-path-fix.patch
+0001-budgie-window-shuffler-dir-path-fix.patch

--- a/src/ubuntu-budgie-extras/package.yml
+++ b/src/ubuntu-budgie-extras/package.yml
@@ -1,0 +1,228 @@
+maintainer : algent-al
+name       : ubuntu-budgie-extras
+version    : 1.0.1
+release    : 6
+source     :
+    - https://github.com/UbuntuBudgie/budgie-extras/releases/download/v1.0.1/budgie-extras-1.0.1.tar.xz : 1c9636a0e8d6ab986d4ac219d4be82d6a8ce26e8dd355ad2be409fcf99e88c36
+homepage   : https://github.com/UbuntuBudgie/budgie-extras
+license    : GPL-3.0-or-later
+component  :
+    - ^budgie-app-launcher-applet : desktop.budgie
+    - ^budgie-applications-menu-applet : desktop.budgie
+    - ^budgie-clockworks-applet : desktop.budgie
+    - ^budgie-dropby-applet : desktop.budgie
+    - ^budgie-fuzzyclock-applet : desktop.budgie
+    - ^budgie-hotcorners-applet : desktop.budgie
+    - ^budgie-keyboard-autoswitch-applet : desktop.budgie
+    - ^budgie-previews : desktop.budgie
+    - ^budgie-quickchar : desktop.budgie
+    - ^budgie-recentlyused-applet : desktop.budgie
+    - ^budgie-showtime-applet : desktop.budgie
+    - ^budgie-visualspace-applet : desktop.budgie
+    - ^budgie-wallstreet : desktop.budgie
+    - ^budgie-window-mover-applet : desktop.budgie
+    - ^budgie-workspace-overview-applet : desktop.budgie
+    - ^budgie-workspace-stopwatch-applet : desktop.budgie
+    - ^budgie-workspace-wallpaper-applet : desktop.budgie
+summary    :
+    - Shared component of budgie-extras applets
+    - ^budgie-app-launcher-applet : Applet to provide an alternative means to launch applications
+    - ^budgie-applications-menu-applet : Stylish Applications Menu for Budgie-Desktop
+    - ^budgie-clockworks-applet : Applet to display clock across multiple time zones
+    - ^budgie-dropby-applet : Applet to popup when a USB device is connected
+    - ^budgie-fuzzyclock-applet : Shows the time in a Fuzzy Way
+    - ^budgie-hotcorners-applet : Applet providing hotcorners capabilities for the Budgie Desktop
+    - ^budgie-keyboard-autoswitch-applet : Applet adding the ability to set a different keyboard layout per application
+    - ^budgie-previews : Provides window previews capabilities for the Budgie Desktop
+    - ^budgie-quickchar : GUI to find and choose locale characters
+    - ^budgie-recentlyused-applet : Applet displays files recently accessed for the Budgie Desktop
+    - ^budgie-showtime-applet : Applet displaying date and time on the Budgie Desktop
+    - ^budgie-visualspace-applet : Show and manage windows in workspaces for the Budgie Desktop
+    - ^budgie-wallstreet : Change wallpaper from a folder on a schedule
+    - ^budgie-window-mover-applet : Applet allows moving windows between workspaces for the Budgie Desktop
+    - ^budgie-workspace-overview-applet : Applet providing quick access to workspaces for the Budgie Desktop
+    - ^budgie-workspace-stopwatch-applet : Workspace usage tracker for the budgie desktop
+    - ^budgie-workspace-wallpaper-applet : Applet providing per workspace wallpaper
+description:
+    - Budgie-extras from Ubuntu Budgie. Here are some applets not yet included in official Solus Repository.
+    - ^budgie-app-launcher-applet : The app-launcher applet allows the ability to add favorite apps to the panel as well as finding and launching applications.  The list of applications listed can be easily configured to be visible or hidden.
+    - ^budgie-applications-menu-applet : The application-menu is a stylish panel applet that displays applications in different views - grid and list. Weblinks typed into the search bar can be opened in your default browser. Applications that have additional desktop options show via a right-click menu. Applications with associated actions show those actions are additional searchable entries.
+    - ^budgie-clockworks-applet : A multi clock applet to show the time across multiple timezones. Clocks can be created and deleted in a single click, and easily be (re-) named. Timezones can be looked up from the applet's popup menu.
+    - ^budgie-dropby-applet : The DropBy applet pops up in the panel when connecting a usb device. The applet subsequently offers the option(s) to mount, unmount/eject and in case of a flash drive, to make a local copy of the drive's content. The info shows the free space on the volume.
+    - ^budgie-fuzzyclock-applet : Displays the time in a 'spoken' format such as five past six.
+    - ^budgie-hotcorners-applet : The hotcorners applet allow user defined commands to be executed when the mouse cursor is pushed into a corner of the main desktop.
+    - ^budgie-keyboard-autoswitch-applet : The Keyboard Auto Switcher applet provides the user the ability to set a different keyboard layout per application. Exceptions to the default layout can be set by simply choosing a different layout using the Keyboard Layout applet.
+    - ^budgie-previews : Set previews to show an overview of windows in an expose like way.
+    - ^budgie-quickchar : Quickly find and choose the equivalent locale character for an ascii character.
+    - ^budgie-recentlyused-applet : The recentlyused applet displays the users files that have been opened or created within a configurable period of time.
+    - ^budgie-showtime-applet : Budgie Showtime is a digital desktop clock, showing time, and optionally, date. Text color of both can be set separately from the applet's menu.
+    - ^budgie-visualspace-applet : The visualspace applet shows as a stylish compact workspace on the budgie panel. Choosing windows in the applet popup moves to the workspace where the window is located and gives it focus. The number of Workspace can also be changed though the applet popup.
+    - ^budgie-wallstreet : Wallstreet allows for a directory of pictures to be shown on a schedule.
+    - ^budgie-window-mover-applet : The Window Mover applet allows the user to quickly move windows to any of the other workspaces. Just drag a window to the bottom of the screen and a bar will popup, representing the workspaces. Click on any of the numbers (or press the corresponding number on the keyboard) and the window will move to that workspace.
+    - ^budgie-workspace-overview-applet : The workspace overview applet allows a user to quickly navigate workspaces using the applet's menu. Optionally, navigation to any window in any workspace is possible.
+    - ^budgie-workspace-stopwatch-applet : Workspace Stopwatch Applet keeps track of usage per workspace, i.e. to find out how much minutes/hours were actually spent on a job. Workspaces can be freely named, custom names and all data are remembered.
+    - ^budgie-workspace-wallpaper-applet : The workspace wallpaper applet shows a different wallpaper on each of the workspaces. Usage is simple; add the applet to the panel and set wallpapers on each of the workspaces in the way you are used to. The applet will remember what wallpaper was set on each of the workspaces.
+patterns   :
+    - ^budgie-app-launcher-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-app-launcher
+        - /usr/share/pixmaps/budgie-app-launcher*
+    - ^budgie-applications-menu-applet :
+        - /usr/lib64/budgie-desktop/plugins/applications-menu
+        - /usr/share/glib-2.0/schemas/io.elementary.desktop.wingpanel.applications-menu.gschema.xml
+    - ^budgie-clockworks-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-clockworks
+        - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-clockworks.gschema.xml
+        - /usr/share/pixmaps/budgie-clockworks-symbolic.svg
+    - ^budgie-dropby-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-dropby
+        - /usr/share/pixmaps/budgie-dropby*
+    - ^budgie-fuzzyclock-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-fuzzyclock
+    - ^budgie-hotcorners-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-hotcorners
+        - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-hotcorners.gschema.xml
+        - /usr/share/pixmaps/budgie-hotcorners-symbolic.svg
+    - ^budgie-keyboard-autoswitch-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-keyboard-autoswitch
+        - /usr/share/pixmaps/budgie-keyboard-autoswitch-symbolic.svg
+    - ^budgie-previews :
+        - /usr/lib64/budgie-previews
+        - /usr/share/applications/previewscontrols.desktop 
+        - /usr/share/budgie-extras-daemon/preview*
+        - /usr/share/glib-2.0/schemas/org.ubuntubudgie.budgie-wpreviews.gschema.xml
+        - /usr/share/pixmaps/budgie_wpreviews*
+        - /usr/share/pixmaps/budgiewprviews.svg
+        - /usr/share/xdg/autostart/previews*
+    - ^budgie-quickchar :
+        - /usr/bin/quickchar
+        - /usr/lib64/quickchar
+        - /usr/share/applications/quickchar.desktop
+        - /usr/share/budgie-extras-daemon/quickchar.bde
+        - /usr/share/glib-2.0/schemas/org.ubuntubudgie.quickchar.gschema.xml
+        - /usr/share/man/man1/quickchar.1
+        - /usr/share/quickchar/chardata
+        - /usr/share/xdg/autostart/quickchar-autostart.desktop
+    - ^budgie-recentlyused-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-recentlyused
+        - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-recentlyused.gschema.xml
+    - ^budgie-showtime-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-showtime
+        - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-showtime.gschema.xml
+        - /usr/share/pixmaps/showtimenew-symbolic.svg
+    - ^budgie-visualspace-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-visualspace
+        - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-visualspace.gschema.xml
+        - /usr/share/pixmaps/visualspace-symbolic.svg
+        - /usr/share/xdg/autostart/visualspace-autostart.desktop
+    - ^budgie-wallstreet :
+        - /usr/lib64/budgie-wallstreet/wallstreet*
+        - /usr/share/applications/wallstreet-control.desktop
+        - /usr/share/glib-2.0/schemas/org.ubuntubudgie.budgie-wallstreet.gschema.xml
+        - /usr/share/pixmaps/wallstreet-control.svg
+        - /usr/share/xdg/autostart/wallstreet-autostart.desktop
+    - ^budgie-window-mover-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-wmover
+        - /usr/share/pixmaps/budgie-wmover-symbolic.svg
+    - ^budgie-workspace-overview-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-wsoverview
+        - /usr/share/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-wsoverview.gschema.xml
+        - /usr/share/pixmaps/budgie-wsoverview-symbolic.svg
+        - /usr/share/pixmaps/ws*
+    - ^budgie-workspace-stopwatch-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-workspace-stopwatch
+        - /usr/share/pixmaps/budgie-wstopwatch-symbolic.svg
+    - ^budgie-workspace-wallpaper-applet :
+        - /usr/lib64/budgie-desktop/plugins/budgie-wswitcher
+        - /usr/share/pixmaps/budgie-wsw-symbolic.svg
+builddeps  :
+    - pkgconfig(appstream)
+    - pkgconfig(budgie-1.0)
+    - pkgconfig(gnome-settings-daemon)
+    - pkgconfig(granite)
+    - pkgconfig(json-glib-1.0)
+    - pkgconfig(keybinder-3.0)
+    - pkgconfig(libgnome-menu-3.0)
+    - pkgconfig(libsoup-2.4)
+    - pkgconfig(libwnck-3.0)
+    - pkgconfig(plank)
+    - pkgconfig(zeitgeist-2.0)
+    - vala
+rundeps    :
+    - ^budgie-app-launcher-applet : budgie-extras
+    - ^budgie-applications-menu-applet : budgie-extras
+    - ^budgie-clockworks-applet :
+        - budgie-extras
+        - python-cairosvg
+        - python-pillow
+        - python-svgwrite
+    - ^budgie-dropby-applet :
+        - budgie-extras
+        - python-psutil
+        - python3-pyudev
+        - wmctrl
+    - ^budgie-fuzzyclock-applet : budgie-extras
+    - ^budgie-hotcorners-applet :
+        - budgie-previews
+        - xdotool
+    - ^budgie-keyboard-autoswitch-applet :
+        - budgie-extras
+        - python-psutil
+        - xdotool
+        - xprop
+    - ^budgie-previews :
+        - budgie-extras-daemon
+        - xinput
+        - xprintidle
+    - ^budgie-quickchar :
+        - budgie-extras-daemon
+        - python-pyperclip
+        - python-xlib
+        - wmctrl
+    - ^budgie-recentlyused-applet : budgie-extras
+    - ^budgie-showtime-applet : budgie-extras
+    - ^budgie-visualspace-applet : budgie-extras
+    - ^budgie-wallstreet : budgie-extras-daemon
+    - ^budgie-window-mover-applet :
+        - budgie-extras
+        - python-psutil
+        - xdotool
+        - xprop
+        - wmctrl
+    - ^budgie-workspace-overview-applet :
+        - budgie-extras
+        - python-psutil
+        - xprop
+        - wmctrl
+    - ^budgie-workspace-stopwatch-applet : budgie-extras
+    - ^budgie-workspace-wallpaper-applet :
+        - budgie-extras
+        - python-psutil
+        - wmctrl
+setup      : |
+    %apply_patches
+    %meson_configure --sysconfdir=/usr/share \
+        -Dbuild-all=false \
+        -Dbuild-app-launcher=true \
+        -Dbuild-applications-menu=true \
+        -Dbuild-clockworks=true \
+        -Dbuild-dropby=true \
+        -Dbuild-fuzzyclock=true \
+        -Dbuild-hotcorners=true \
+        -Dbuild-keyboard-autoswitch=true \
+        -Dbuild-quickchar=true \
+        -Dbuild-recentlyused=true \
+        -Dbuild-showtime=true \
+        -Dbuild-visualspace=true \
+        -Dbuild-wallstreet=true \
+        -Dbuild-wmover=true \
+        -Dbuild-workspacestopwatch=true \
+        -Dbuild-wpreviews=true \
+        -Dbuild-wsoverview=true \
+        -Dbuild-wswitcher=true
+build      : |
+    %ninja_build
+install    : |
+    %ninja_install
+
+    #These are not needed since they are already in budgie-extras to avoid conflicts.
+    rm -rf $installdir/usr/share/locale

--- a/src/wmctrl/files/wmctrl_1.07-6.diff
+++ b/src/wmctrl/files/wmctrl_1.07-6.diff
@@ -1,0 +1,423 @@
+--- wmctrl-1.07.orig/debian/control
++++ wmctrl-1.07/debian/control
+@@ -0,0 +1,20 @@
++Source: wmctrl
++Section: x11
++Priority: optional
++Maintainer: Decklin Foster <decklin@red-bean.com>
++Build-Depends: debhelper (>= 4.0.0), x11proto-core-dev, libx11-dev, libxmu-dev, libglib2.0-dev (>= 2.4.0)
++Standards-Version: 3.6.2
++
++Package: wmctrl
++Architecture: any
++Depends: ${shlibs:Depends}
++Description: control an EWMH/NetWM compatible X Window Manager
++ Wmctrl is a command line tool to interact with an
++ EWMH/NetWM compatible X Window Manager (examples include
++ Enlightenment, icewm, kwin, metacity, and sawfish).
++ .
++ Wmctrl provides command line access to almost all the features
++ defined in the EWMH specification. For example it can maximize
++ windows, make them sticky, set them to be always on top. It can
++ switch and resize desktops and perform many other useful
++ operations.
+--- wmctrl-1.07.orig/debian/wmctrl.docs
++++ wmctrl-1.07/debian/wmctrl.docs
+@@ -0,0 +1 @@
++README
+--- wmctrl-1.07.orig/debian/watch
++++ wmctrl-1.07/debian/watch
+@@ -0,0 +1,2 @@
++version=2
++http://sweb.cz/tripie/utils/wmctrl/dist/ wmctrl-(.*)\.tar\.gz debian uupdate
+--- wmctrl-1.07.orig/debian/compat
++++ wmctrl-1.07/debian/compat
+@@ -0,0 +1 @@
++4
+--- wmctrl-1.07.orig/debian/changelog
++++ wmctrl-1.07/debian/changelog
+@@ -0,0 +1,69 @@
++wmctrl (1.07-6) unstable; urgency=low
++
++  * Reverted CARD32 patch, which was broken on amd64; use fix from Chris
++    Donoghue instead. (Closes: #362068)
++  * Change x-dev -> x11proto-core-dev build-dep.
++
++ -- Decklin Foster <decklin@red-bean.com>  Tue, 18 Apr 2006 10:20:00 -0400
++
++wmctrl (1.07-5) unstable; urgency=low
++
++  * Not all the new build-deps from -2 were actually added to debian/control.
++    (Closes: #345816)
++
++ -- Decklin Foster <decklin@red-bean.com>  Tue,  3 Jan 2006 14:26:57 -0500
++
++wmctrl (1.07-4) unstable; urgency=low
++
++  * Get rid of huge mess in .diff.gz caused by vim's braindead folding.
++
++ -- Decklin Foster <decklin@red-bean.com>  Mon,  2 Jan 2006 23:27:14 -0500
++
++wmctrl (1.07-3) unstable; urgency=low
++
++  * Fix typo in description (Closes: #345576)
++
++ -- Decklin Foster <decklin@red-bean.com>  Mon,  2 Jan 2006 22:53:30 -0500
++
++wmctrl (1.07-2) unstable; urgency=low
++
++  * Patch main.c to use CARD32 for all EWMH properties instead of unsigned
++    long, which may be 64 bits on 64-bit archs. (Closes: #344080)
++  * Replace xlibs-dev build-dep with libx11-dev, x-dev, libxmu-dev.
++  * Update Standards-Version to 3.6.2.
++
++ -- Decklin Foster <decklin@red-bean.com>  Mon,  2 Jan 2006 22:34:27 -0500
++
++wmctrl (1.07-1) unstable; urgency=low
++
++  * New upstream release
++
++ -- Decklin Foster <decklin@red-bean.com>  Sat, 29 Jan 2005 09:45:14 -0500
++
++wmctrl (1.06-1) unstable; urgency=low
++
++  * New upstream release
++    - debian/wmctrl.1: merged upstream.
++  * debian/watch: added trailing / to directory (Thanks, Shyamal).
++  * debian/control: lowercase first letter of description.
++
++ -- Decklin Foster <decklin@red-bean.com>  Sat, 22 Jan 2005 14:04:09 -0500
++
++wmctrl (1.05-2) unstable; urgency=low
++
++  * Adopting package created by Debian user Shyamal Prasad
++    <shyamal@member.fsf.org>.
++  * Removed debian/{pre,post}{inst,rm}.ex and config.{sub,guess}, and do not
++    generate config.{sub,guess} in clean.
++  * Removed example cruft in copyright and watch.
++  * Install ChangeLog as the upstream changelog, not a doc. Do not install
++    NEWS, since it is empty.
++
++ -- Decklin Foster <decklin@red-bean.com>  Mon, 13 Dec 2004 10:41:11 -0500
++
++wmctrl (1.05-1) unstable; urgency=low
++
++  * Initial Release. Added man page wmctrl.1 (closes: #285397)
++
++ -- Shyamal Prasad <shyamal@member.fsf.org>  Thu, 12 Dec 2004 18:59:40 -0800
++
+--- wmctrl-1.07.orig/debian/rules
++++ wmctrl-1.07/debian/rules
+@@ -0,0 +1,91 @@
++#!/usr/bin/make -f
++# -*- makefile -*-
++# Sample debian/rules that uses debhelper.
++# This file was originally written by Joey Hess and Craig Small.
++# As a special exception, when this file is copied by dh-make into a
++# dh-make output file, you may use that output file without restriction.
++# This special exception was added by Craig Small in version 0.37 of dh-make.
++
++# Uncomment this to turn on verbose mode.
++#export DH_VERBOSE=1
++
++
++# These are used for cross-compiling and for saving the configure script
++# from having to guess our platform (since we know it already)
++DEB_HOST_GNU_TYPE   ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
++DEB_BUILD_GNU_TYPE  ?= $(shell dpkg-architecture -qDEB_BUILD_GNU_TYPE)
++
++
++CFLAGS = -Wall -g
++
++ifneq (,$(findstring noopt,$(DEB_BUILD_OPTIONS)))
++	CFLAGS += -O0
++else
++	CFLAGS += -O2
++endif
++
++config.status: configure
++	dh_testdir
++	# Add here commands to configure the package.
++	CFLAGS="$(CFLAGS)" ./configure --host=$(DEB_HOST_GNU_TYPE) --build=$(DEB_BUILD_GNU_TYPE) --prefix=/usr --mandir=\$${prefix}/share/man --infodir=\$${prefix}/share/info
++
++
++build: build-stamp
++
++build-stamp:  config.status
++	dh_testdir
++
++	# Add here commands to compile the package.
++	$(MAKE)
++
++	touch build-stamp
++
++clean:
++	dh_testdir
++	dh_testroot
++	rm -f build-stamp 
++
++	# Add here commands to clean up after the build process.
++	-$(MAKE) distclean
++
++	dh_clean 
++
++install: build
++	dh_testdir
++	dh_testroot
++	dh_clean -k 
++	dh_installdirs
++
++	# Add here commands to install the package into debian/wmctrl.
++	$(MAKE) install DESTDIR=$(CURDIR)/debian/wmctrl
++
++
++# Build architecture-independent files here.
++binary-indep: build install
++# We have nothing to do by default.
++
++# Build architecture-dependent files here.
++binary-arch: build install
++	dh_testdir
++	dh_testroot
++	dh_installchangelogs ChangeLog
++	dh_installdocs
++	dh_installexamples
++#	dh_install
++#	dh_installmenu
++#	dh_installlogrotate
++#	dh_installinit
++#	dh_installinfo
++	dh_link
++	dh_strip
++	dh_compress
++	dh_fixperms
++#	dh_makeshlibs
++	dh_installdeb
++	dh_shlibdeps
++	dh_gencontrol
++	dh_md5sums
++	dh_builddeb
++
++binary: binary-indep binary-arch
++.PHONY: build clean binary-indep binary-arch binary install 
+--- wmctrl-1.07.orig/debian/copyright
++++ wmctrl-1.07/debian/copyright
+@@ -0,0 +1,15 @@
++This package was debianized by Shyamal Prasad <shyamal@member.fsf.org> on
++Thu, 12 Dec 2004 18:59:40 -0800.
++
++It was downloaded from http://sweb.cz/tripie/utils/wmctrl/
++
++Upstream Author: Tomas Styblo <tripie@cpan.org>
++
++Copyright (C) 2003, Tomas Styblo <tripie@cpan.org>
++
++You are free to distribute this software under the terms of the GNU
++General Public License.
++
++On Debian systems, the complete text of the GNU General Public License
++can be found in the file `/usr/share/common-licenses/GPL'.
++
+--- wmctrl-1.07.orig/BAH
++++ wmctrl-1.07/BAH
+@@ -0,0 +1,172 @@
++--- wmctrl-1.07.orig/main.c
+++++ wmctrl-1.07/main.c
++@@ -31,6 +31,7 @@
++ #include <string.h>
++ #include <locale.h>
++ #include <X11/Xlib.h>
+++#include <X11/Xmd.h>
++ #include <X11/Xatom.h>
++ #include <X11/cursorfont.h>
++ #include <X11/Xmu/WinUtil.h>
++@@ -477,8 +478,8 @@
++     Window *sup_window = NULL;
++     gchar *wm_name = NULL;
++     gchar *wm_class = NULL;
++-    unsigned long *wm_pid = NULL;
++-    unsigned long *showing_desktop = NULL;
+++    CARD32 *wm_pid = NULL;
+++    CARD32 *showing_desktop = NULL;
++     gboolean name_is_utf8 = TRUE;
++     gchar *name_out;
++     gchar *class_out;
++@@ -517,13 +518,13 @@
++   
++ 
++     /* WM_PID */
++-    if (! (wm_pid = (unsigned long *)get_property(disp, *sup_window,
+++    if (! (wm_pid = (CARD32 *)get_property(disp, *sup_window,
++                     XA_CARDINAL, "_NET_WM_PID", NULL))) {
++         p_verbose("Cannot get pid of the window manager (_NET_WM_PID).\n");
++     }
++     
++     /* _NET_SHOWING_DESKTOP */
++-    if (! (showing_desktop = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++    if (! (showing_desktop = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                     XA_CARDINAL, "_NET_SHOWING_DESKTOP", NULL))) {
++         p_verbose("Cannot get the _NET_SHOWING_DESKTOP property.\n");
++     }
++@@ -678,13 +679,13 @@
++ }/*}}}*/
++ 
++ static int window_to_desktop (Display *disp, Window win, int desktop) {/*{{{*/
++-    unsigned long *cur_desktop = NULL;
+++    CARD32 *cur_desktop = NULL;
++     Window root = DefaultRootWindow(disp);
++    
++     if (desktop == -1) {
++-        if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+++        if (! (cur_desktop = (CARD32 *)get_property(disp, root,
++                 XA_CARDINAL, "_NET_CURRENT_DESKTOP", NULL))) {
++-            if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+++            if (! (cur_desktop = (CARD32 *)get_property(disp, root,
++                     XA_CARDINAL, "_WIN_WORKSPACE", NULL))) {
++                 fputs("Cannot get current desktop properties. "
++                       "(_NET_CURRENT_DESKTOP or _WIN_WORKSPACE property)"
++@@ -702,12 +703,12 @@
++ 
++ static int activate_window (Display *disp, Window win, /* {{{ */
++         gboolean switch_desktop) {
++-    unsigned long *desktop;
+++    CARD32 *desktop;
++ 
++     /* desktop ID */
++-    if ((desktop = (unsigned long *)get_property(disp, win,
+++    if ((desktop = (CARD32 *)get_property(disp, win,
++             XA_CARDINAL, "_NET_WM_DESKTOP", NULL)) == NULL) {
++-        if ((desktop = (unsigned long *)get_property(disp, win,
+++        if ((desktop = (CARD32 *)get_property(disp, win,
++                 XA_CARDINAL, "_WIN_WORKSPACE", NULL)) == NULL) {
++             p_verbose("Cannot find desktop ID of the window.\n");
++         }
++@@ -1016,16 +1017,16 @@
++ }/*}}}*/
++ 
++ static int list_desktops (Display *disp) {/*{{{*/
++-    unsigned long *num_desktops = NULL;
++-    unsigned long *cur_desktop = NULL;
+++    CARD32 *num_desktops = NULL;
+++    CARD32 *cur_desktop = NULL;
++     unsigned long desktop_list_size = 0;
++-    unsigned long *desktop_geometry = NULL;
+++    CARD32 *desktop_geometry = NULL;
++     unsigned long desktop_geometry_size = 0;
++     gchar **desktop_geometry_str = NULL;
++-    unsigned long *desktop_viewport = NULL;
+++    CARD32 *desktop_viewport = NULL;
++     unsigned long desktop_viewport_size = 0;
++     gchar **desktop_viewport_str = NULL;
++-    unsigned long *desktop_workarea = NULL;
+++    CARD32 *desktop_workarea = NULL;
++     unsigned long desktop_workarea_size = 0;
++     gchar **desktop_workarea_str = NULL;
++     gchar *list = NULL;
++@@ -1036,9 +1037,9 @@
++     gchar **names = NULL;
++     gboolean names_are_utf8 = TRUE;
++     
++-    if (! (num_desktops = (unsigned long *)get_property(disp, root,
+++    if (! (num_desktops = (CARD32 *)get_property(disp, root,
++             XA_CARDINAL, "_NET_NUMBER_OF_DESKTOPS", NULL))) {
++-        if (! (num_desktops = (unsigned long *)get_property(disp, root,
+++        if (! (num_desktops = (CARD32 *)get_property(disp, root,
++                 XA_CARDINAL, "_WIN_WORKSPACE_COUNT", NULL))) {
++             fputs("Cannot get number of desktops properties. "
++                   "(_NET_NUMBER_OF_DESKTOPS or _WIN_WORKSPACE_COUNT)"
++@@ -1047,9 +1048,9 @@
++         }
++     }
++     
++-    if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+++    if (! (cur_desktop = (CARD32 *)get_property(disp, root,
++             XA_CARDINAL, "_NET_CURRENT_DESKTOP", NULL))) {
++-        if (! (cur_desktop = (unsigned long *)get_property(disp, root,
+++        if (! (cur_desktop = (CARD32 *)get_property(disp, root,
++                 XA_CARDINAL, "_WIN_WORKSPACE", NULL))) {
++             fputs("Cannot get current desktop properties. "
++                   "(_NET_CURRENT_DESKTOP or _WIN_WORKSPACE property)"
++@@ -1074,21 +1075,21 @@
++     }
++  
++     /* common size of all desktops */
++-    if (! (desktop_geometry = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++    if (! (desktop_geometry = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                     XA_CARDINAL, "_NET_DESKTOP_GEOMETRY", &desktop_geometry_size))) {
++         p_verbose("Cannot get common size of all desktops (_NET_DESKTOP_GEOMETRY).\n");
++     }
++      
++     /* desktop viewport */
++-    if (! (desktop_viewport = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++    if (! (desktop_viewport = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                     XA_CARDINAL, "_NET_DESKTOP_VIEWPORT", &desktop_viewport_size))) {
++         p_verbose("Cannot get common size of all desktops (_NET_DESKTOP_VIEWPORT).\n");
++     }
++      
++     /* desktop workarea */
++-    if (! (desktop_workarea = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++    if (! (desktop_workarea = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                     XA_CARDINAL, "_NET_WORKAREA", &desktop_workarea_size))) {
++-        if (! (desktop_workarea = (unsigned long *)get_property(disp, DefaultRootWindow(disp),
+++        if (! (desktop_workarea = (CARD32 *)get_property(disp, DefaultRootWindow(disp),
++                         XA_CARDINAL, "_WIN_WORKAREA", &desktop_workarea_size))) {
++             p_verbose("Cannot get _NET_WORKAREA property.\n");
++         }
++@@ -1301,16 +1302,16 @@
++         gchar *title_out = get_output_str(title_utf8, TRUE);
++         gchar *client_machine;
++         gchar *class_out = get_window_class(disp, client_list[i]); /* UTF8 */
++-        unsigned long *pid;
++-        unsigned long *desktop;
+++        CARD32 *pid;
+++        CARD32 *desktop;
++         int x, y, junkx, junky;
++         unsigned int wwidth, wheight, bw, depth;
++         Window junkroot;
++ 
++         /* desktop ID */
++-        if ((desktop = (unsigned long *)get_property(disp, client_list[i],
+++        if ((desktop = (CARD32 *)get_property(disp, client_list[i],
++                 XA_CARDINAL, "_NET_WM_DESKTOP", NULL)) == NULL) {
++-            desktop = (unsigned long *)get_property(disp, client_list[i],
+++            desktop = (CARD32 *)get_property(disp, client_list[i],
++                     XA_CARDINAL, "_WIN_WORKSPACE", NULL);
++         }
++ 
++@@ -1319,7 +1320,7 @@
++                 XA_STRING, "WM_CLIENT_MACHINE", NULL);
++        
++         /* pid */
++-        pid = (unsigned long *)get_property(disp, client_list[i],
+++        pid = (CARD32 *)get_property(disp, client_list[i],
++                 XA_CARDINAL, "_NET_WM_PID", NULL);
++ 
++ 	    /* geometry */
+--- wmctrl-1.07.orig/main.c
++++ wmctrl-1.07/main.c
+@@ -1425,6 +1425,16 @@
+      *
+      * long_length = Specifies the length in 32-bit multiples of the
+      *               data to be retrieved.
++     *
++     * NOTE:  see 
++     * http://mail.gnome.org/archives/wm-spec-list/2003-March/msg00067.html
++     * In particular:
++     *
++     * 	When the X window system was ported to 64-bit architectures, a
++     * rather peculiar design decision was made. 32-bit quantities such
++     * as Window IDs, atoms, etc, were kept as longs in the client side
++     * APIs, even when long was changed to 64 bits.
++     *
+      */
+     if (XGetWindowProperty(disp, win, xa_prop_name, 0, MAX_PROPERTY_VALUE_LEN / 4, False,
+             xa_prop_type, &xa_ret_type, &ret_format,     
+@@ -1441,6 +1451,8 @@
+ 
+     /* null terminate the result to make string handling easier */
+     tmp_size = (ret_format / 8) * ret_nitems;
++    /* Correct 64 Architecture implementation of 32 bit data */
++    if(ret_format==32) tmp_size *= sizeof(long)/4;
+     ret = g_malloc(tmp_size + 1);
+     memcpy(ret, ret_prop, tmp_size);
+     ret[tmp_size] = '\0';

--- a/src/wmctrl/package.yml
+++ b/src/wmctrl/package.yml
@@ -1,0 +1,22 @@
+maintainer : algent-al
+name       : wmctrl
+version    : 1.07
+release    : 1
+source     :
+    - http://tripie.sweb.cz/utils/wmctrl/dist/wmctrl-1.07.tar.gz : d78a1efdb62f18674298ad039c5cbdb1edb6e8e149bb3a8e3a01a4750aa3cca9
+    - http://archive.debian.org/debian/pool/main/w/wmctrl/wmctrl_1.07-6.diff.gz : c6560ba645652eab0b16d46c9dbd8e5c9881c1f9d3ac6fa3da2ee3c865b5e6a0
+homepage   : http://tripie.sweb.cz/utils/wmctrl/
+license    : GPL-2.0-or-later
+component  : system.utils
+summary    : wmctrl is a UNIX/Linux command line tool to interact with an EWMH/NetWM compatible X Window Manager
+description: |
+    The tool provides command line access to almost all the features defined in the EWMH specification. It can be used, for example, to get information about the window manager, to get a detailed list of desktops and managed windows, to switch and resize desktops, to make windows full-screen, always-above or sticky, and to activate, close, move, resize, maximize and minimize them.
+builddeps  :
+    - pkgconfig(xmu)
+setup      : |
+    %patch -p1 < $pkgfiles/wmctrl_1.07-6.diff
+    %configure
+build      : |
+    %make
+install    : |
+    %make_install


### PR DESCRIPTION
`ubuntu-budgie-extras` have the same source as `budgie-extras` that is in official repo, but here I am adding the applet that are not accepted officially so, they will not conflict.
Release started from 6, since that is the release of `budgie-extras`.
 
Didn't include here:
- budgie-trash-applet (Not necessary there is already one in the repo)
- budgie-brightness-controller-applet (Doesn't work well with NVIDIA Graphics)
- budgie-network-manager-applet (Not necessary)
- budgie-rotation-lock-applet (Can't test this)