### PR TITLE
Add python3-cairo to rundeps

### DIFF
--- a/src/desktop.cinnamon/cinnamon/package.yml
+++ b/src/desktop.cinnamon/cinnamon/package.yml
@@ -41,6 +41,7 @@ rundeps    :
     - python-pillow
     - python-pytz
     - python-tinycss
+    - python3-cairo
 setup      : |
     # Patch from https://github.com/linuxmint/cinnamon/pull/9306
     %patch -p1 <$pkgfiles/Readd-import.patch


### PR DESCRIPTION
I think we should add this as rundep for cinnamon. When I tried this in a VB, I had errors with cinnamon settings not loading. 
In normal situations `system-config-printer` is installed by default and this package have `python3-cairo` as rundep. So maybe this rundep is not necessary. But somehow in my VB install I had removed `system-config-printer` and cleaned all dependencies. I usually clean all stuff that I don't use in VB.  This explains why I had problem when testing `cinnamon`.