### PR TITLE
make sure to replace crond

### DIFF
--- a/src/cronie/package.yml
+++ b/src/cronie/package.yml
@@ -1,7 +1,7 @@
 maintainer : algent-al
 name       : cronie
 version    : 1.5.5
-release    : 1
+release    : 2
 source     :
     - https://github.com/cronie-crond/cronie/releases/download/cronie-1.5.5/cronie-1.5.5.tar.gz : be34c79505e5544323281854744b9955ff16b160ee569f9df7c0dddae5720eac
 homepage   : https://github.com/cronie-crond/cronie
@@ -14,6 +14,8 @@ component  : system.utils
 summary    : Cronie cron daemon project 
 description: |
     Cronie contains the standard UNIX daemon crond that runs specified programs at scheduled times and related tools. The source is based on the original vixie-cron and has security and configuration enhancements like the ability to use pam and SELinux.
+replaces   :
+    - crond
 setup      : |
     %configure \
         --sbindir=/usr/bin \


### PR DESCRIPTION
I don't have any idea if any user had already install `timeshift` with `crond` as rundep. 
This patch is to make sure to replace `crond` with `cronie`.