### PR TITLE
youtube-dlg: Replace python-twodict with python2-twodict

### DIFF
--- a/src/network/download/youtube-dlg/package.yml
+++ b/src/network/download/youtube-dlg/package.yml
@@ -1,7 +1,7 @@
 maintainer : algent-al
 name       : youtube-dlg
 version    : 0.4
-release    : 1
+release    : 2
 source     :
     - https://github.com/MrS0m30n3/youtube-dl-gui/archive/0.4.tar.gz : 70d7729a51a463f8b4d05e765681cff8f7444282ab5f29a4b71cc2f0fba00065
 homepage   : https://mrs0m30n3.github.io/youtube-dl-gui/
@@ -9,14 +9,14 @@ license    : Unlicense
 component  : network.download
 summary    : youtube-dlg (or youtube-dl-gui), is a GUI of the popular youtube-dl.
 description: |
-     youtube-dlg (or youtube-dl-gui) is a cross platform front-end GUI of the popular youtube-dl written in wxPython.
+    youtube-dlg (or youtube-dl-gui) is a cross platform front-end GUI of the popular youtube-dl written in wxPython.
 builddeps  :
     - pkgconfig(libavformat)
-    - python-twodict
+    - python2-twodict
     - wxPython-devel
 rundeps    :
     - wxPython
-    - python-twodict
+    - python2-twodict
 build      : |
     %python_setup
 install    : |

--- a/src/programming/python/python2-twodict/package.yml
+++ b/src/programming/python/python2-twodict/package.yml
@@ -1,0 +1,16 @@
+maintainer : algent-al
+name       : python2-twodict
+version    : 1.2
+release    : 1
+source     :
+    - https://github.com/MrS0m30n3/twodict/archive/1.2.tar.gz : 1e9a3333cc5d3f87b0ad21da1ffb071556f0e9206026365a9b47d7d73d90d639
+homepage   : https://github.com/MrS0m30n3/twodict
+license    : Unlicense
+component  : programming.python
+summary    : Simple two way ordered dictionary for Python
+description: |
+    Simple two way ordered dictionary for Python
+build      : |
+    %python_setup
+install    : |
+    %python_install

--- a/src/series
+++ b/src/series
@@ -65,6 +65,7 @@
 - python-pam
 - python-svgwrite
 - python-tinycss
+- python2-twodict
 - qview
 - sideload
 - skippy-xd
@@ -81,7 +82,6 @@
 - wmctrl
 - xapps
 - xfce4-dev-tools
-- youtube-dlg
 # group separator
 - appstream
 - awesomewm
@@ -103,6 +103,7 @@
 - python-tinycss2
 - qtermwidget
 - xfconf
+- youtube-dlg
 # group separator
 - cinnamon-control-center
 - cjs


### PR DESCRIPTION
`python-twodict` is deprecated. To keep `youtube-dlg` working, I am adding here `python2-twodict`.