### PR TITLE
dekstop.theme: pocillo-gtk-theme: rebuild

### DIFF
--- a/.make/common.py
+++ b/.make/common.py
@@ -111,7 +111,7 @@ class eopkg(object):
 def sol_build(eopkg):
     log = open(eopkg.yml.replace('package.yml', os.environ['BUILD_LOG']), 'w')
     try:
-        subprocess.Popen(['sudo', 'solbuild', 'build', 'package.yml', '-p', 'theca-x86_64'], cwd=os.path.dirname(
+        subprocess.Popen(['sudo', 'solbuild', 'build', '-p', 'theca-x86_64'], cwd=os.path.dirname(
             eopkg.yml), stdout=log, stderr=subprocess.STDOUT).communicate()
     except subprocess.CalledProcessError as e:
         print('Unable to build {}: [{}] {}'.format(

--- a/src/desktop/theme/pocillo-gtk-theme/package.yml
+++ b/src/desktop/theme/pocillo-gtk-theme/package.yml
@@ -1,7 +1,7 @@
 maintainer : algent-al
 name       : pocillo-gtk-theme
 version    : 0.6
-release    : 1
+release    : 2
 source     :
     - https://github.com/UbuntuBudgie/pocillo-gtk-theme/archive/v0.6.tar.gz : eb91742cd4240e2e2ba48abfdb8022bc3886c2f72b480a6111487cee771f0da9
 homepage   : https://github.com/UbuntuBudgie/pocillo-gtk-theme


### PR DESCRIPTION
I get so many errors if I install this theme using Theca repository. Build it locally and install it those errors doesn't show anymore. Maybe it needs just a simple rebuild. If not we have to find why it happens.

These are the errors that I get after installing `pocillo-gtk-theme` built locally, which is the working one.
```
$ sudo eopkg it pocillo-gtk-theme-0.6-1-1-x86_64.eopkg 
Password: 
Installation order: pocillo-gtk-theme 
Installing pocillo-gtk-theme, version 0.6, release 1
Extracting the files of pocillo-gtk-theme
Installed file /usr/share/themes/Pocillo-dark-slim/gtk-2.0/assets does not exist on system [Probably you manually deleted]
Installed file /usr/share/themes/Pocillo-dark/gtk-2.0/assets does not exist on system [Probably you manually deleted]
Installed file /usr/share/themes/Pocillo-light-slim/gtk-2.0/assets does not exist on system [Probably you manually deleted]
Installed file /usr/share/themes/Pocillo-light/gtk-2.0/assets does not exist on system [Probably you manually deleted]
Installed file /usr/share/themes/Pocillo-slim/gtk-2.0/assets does not exist on system [Probably you manually deleted]
Installed file /usr/share/themes/Pocillo/gtk-2.0/assets does not exist on system [Probably you manually deleted]
Installed pocillo-gtk-theme
 [✓] Syncing filesystems 
```
