### PR TITLE
system.utils: procs: first dump

### DIFF
--- a/src/series
+++ b/src/series
@@ -63,6 +63,7 @@
 - pantheon-videos
 - pantheon-wallpapers
 - pocillo-gtk-theme
+- procs
 - pytest-isort
 - python-pam
 - python-svgwrite

--- a/src/system/utils/procs/package.yml
+++ b/src/system/utils/procs/package.yml
@@ -1,0 +1,25 @@
+maintainer : algent-al
+name       : procs
+version    : 0.11.3
+release    : 1
+source     :
+    - https://github.com/dalance/procs/archive/v0.11.3.tar.gz : bf56fde52d0f6544a2ca3db6d4552867e5cf9daf1c5a31f8b3ad6e3258986b0f
+homepage   : https://github.com/dalance/procs
+license    : MIT
+component  : system.utils
+summary    : A modern replacement for ps written in Rust 
+description: |
+    procs is a modern replacement for ps written in Rust.
+networking : yes
+builddeps  :
+    - cargo
+build      : |
+    cargo build --release
+    target/release/procs --completion bash
+    target/release/procs --completion fish
+    target/release/procs --completion zsh
+install    : |
+    install -Dm00755 target/release/procs -t $installdir/usr/bin/
+    install -Dm00644 _procs -t $installdir/usr/share/zsh/site-functions
+    install -Dm00644 procs.bash $installdir/usr/share/bash-completion/completions/procs
+    install -Dm00644 procs.fish -t $installdir/usr/share/fish/vendor_completions.d


### PR DESCRIPTION
This is a replacement for ps written in Rust. It is fast and colourful.
Run `procs` for all packages or `procs <process-name>` or `procs <number>`.