### PR TITLE
desktop.pantheon: pantheon-term: bump

### DIFF
--- a/src/desktop/pantheon/terminal/package.yml
+++ b/src/desktop/pantheon/terminal/package.yml
@@ -1,14 +1,16 @@
 maintainer : streambinder
 name       : pantheon-term
 version    : 5.5.2
-release    : 23
+release    : 24
 source     :
     - https://github.com/elementary/terminal/archive/5.5.2.tar.gz : 589ad0225e3a45700d95c8ead1b646f22a22c7688f647876a5329b3b4bd923cd
 license    : GPL-3.0-only
 component  : desktop.pantheon
-summary    : A super lightweight, beautiful, and simple terminal.
+summary    : A super lightweight, beautiful, and simple terminal
 description: |
     A super lightweight, beautiful, and simple terminal. It's designed to be setup with sane defaults and little to no configuration. It's just a terminal, nothing more, nothing less.
+replaces   :
+    - pantheon-terminal
 builddeps  :
     - pkgconfig(gtk+-3.0)
     - pkgconfig(granite)


### PR DESCRIPTION
Looks like that pantheon-term isn't found.

```
algent@budgie ~ $ sudo eopkg it -c desktop.pantheon
System error. Program terminated.
pantheon-term dependency of package pantheon-default-settings is not satisfied
Please use 'eopkg help' for general help.
Use --debug to see a traceback.
```

Maybe this is because I didn't add `replaces: pantheon-terminal`. Let's try to build this again and see what happens.